### PR TITLE
Add a dummy test to silence pytest

### DIFF
--- a/tests/test_nothing.py
+++ b/tests/test_nothing.py
@@ -1,0 +1,3 @@
+# Observe the best testing practices of them all
+def test_nothing() -> None:
+    assert True


### PR DESCRIPTION
Because when there are no tests, pytest returns with a non-zero exit
code which fails CI build.